### PR TITLE
correct header #include to upper case

### DIFF
--- a/libraries/FatFs/src/integer.h
+++ b/libraries/FatFs/src/integer.h
@@ -13,7 +13,7 @@ typedef unsigned __int64 QWORD;
 
 #else			/* Embedded platform */
 
-#include <arduino.h>
+#include <Arduino.h>
 
 /* This type MUST be 8 bit */
 typedef unsigned char   BYTE;


### PR DESCRIPTION
-> will build on my Mac with case-sensitive file system

Maybe this also fixes build issues on Linux?
